### PR TITLE
feat: support custom certificate resolver name and DNS resolvers

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,9 +82,11 @@ This Ansible role provides automated deployment of Traefik v3.6.5 as a container
 
 | Variable | Default | Description |
 |----------|---------|-------------|
+| `traefik_certresolver_name` | `"live"` | Certificate resolver name (referenced in entrypoints and labels) |
 | `traefik_acme_challenge_type` | `"http"` | Challenge type: `"http"` or `"dns"` |
 | `traefik_acme_dns_provider` | `""` | DNS provider (e.g., `cloudflare`, `route53`, `digitalocean`, `ovh`) |
 | `traefik_acme_dns_env` | `{}` | DNS provider environment variables (credentials) |
+| `traefik_acme_dns_resolvers` | `[]` | Custom DNS resolvers for validation (e.g., `["1.1.1.1:53", "8.8.8.8:53"]`) |
 | `traefik_acme_email` | `""` | Email for Let's Encrypt notifications (optional but recommended) |
 | `traefik_acme_dns_delay_before_check` | `0` | Delay before DNS record verification (seconds) |
 
@@ -260,6 +262,33 @@ Minimal playbook for Traefik with Let's Encrypt:
     traefik_acme_email: "admin@example.com"
     traefik_acme_dns_env:
       DO_AUTH_TOKEN: "your-digitalocean-auth-token"
+
+  roles:
+    - tripleawwy.traefik_docker
+```
+
+### Custom Certificate Resolver Name and DNS Resolvers
+
+```yaml
+---
+- name: Deploy Traefik with Custom Resolver Name and DNS Servers
+  hosts: traefik_servers
+  become: true
+
+  vars:
+    # Match resolver name to provider for semantic clarity
+    traefik_certresolver_name: "hetzner"
+    traefik_acme_challenge_type: "dns"
+    traefik_acme_dns_provider: "hetzner"
+    traefik_acme_email: "admin@example.com"
+
+    # Custom DNS resolvers for validation
+    traefik_acme_dns_resolvers:
+      - "1.1.1.1:53"
+      - "8.8.8.8:53"
+
+    traefik_acme_dns_env:
+      HETZNER_API_KEY: "your-hetzner-api-key"
 
   roles:
     - tripleawwy.traefik_docker

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -23,6 +23,9 @@ traefik_image: "{{ traefik_image_name }}:{{ traefik_image_tag }}"
 traefik_image_name: "traefik"
 traefik_image_tag: "3.6.5"
 # ACME challenge configuration
+# Certificate resolver name (referenced in entrypoints and labels)
+traefik_certresolver_name: "live"
+
 # Challenge type: "http" or "dns"
 traefik_acme_challenge_type: "http"
 
@@ -38,6 +41,11 @@ traefik_acme_dns_provider: ""
 # Example for DigitalOcean:
 #   DO_AUTH_TOKEN: your_auth_token
 traefik_acme_dns_env: {}
+
+# Custom DNS resolvers for DNS challenge validation
+# Empty list uses provider defaults
+# Example: ["1.1.1.1:53", "8.8.8.8:53"]
+traefik_acme_dns_resolvers: []
 
 # ACME email for Let's Encrypt notifications
 traefik_acme_email: ""
@@ -59,24 +67,42 @@ traefik_cli_base:
   - "--entrypoints.web.http.redirections.entrypoint.scheme=https"
   - "--entrypoints.web_secure.address=:443"
   - "--entrypoints.web_secure.http.tls=true"
-  - "--entrypoints.web_secure.http.tls.certresolver=live"
-  - "--certificatesresolvers.live=true"
+  - "--entrypoints.web_secure.http.tls.certresolver={{ traefik_certresolver_name }}"
+  - "--certificatesresolvers.{{ traefik_certresolver_name }}=true"
 
 # HTTP challenge configuration (default)
 traefik_cli_http_challenge:
-  - "--certificatesresolvers.live.acme.httpchallenge=true"
-  - "--certificatesresolvers.live.acme.httpchallenge.entrypoint=web"
+  - "--certificatesresolvers.{{ traefik_certresolver_name }}.acme.httpchallenge=true"
+  - >-
+    --certificatesresolvers.{{ traefik_certresolver_name }}.acme.httpchallenge.entrypoint=web
 
 # DNS challenge configuration
-traefik_cli_dns_challenge:
-  - "--certificatesresolvers.live.acme.dnschallenge=true"
-  - "--certificatesresolvers.live.acme.dnschallenge.provider={{ traefik_acme_dns_provider }}"
-  - "--certificatesresolvers.live.acme.dnschallenge.delaybeforecheck={{ traefik_acme_dns_delay_before_check }}"
+traefik_cli_dns_challenge_base:
+  - "--certificatesresolvers.{{ traefik_certresolver_name }}.acme.dnschallenge=true"
+  - >-
+    --certificatesresolvers.{{ traefik_certresolver_name }}.acme.dnschallenge.provider={{
+    traefik_acme_dns_provider }}
+  - >-
+    --certificatesresolvers.{{ traefik_certresolver_name }}.acme.dnschallenge.delaybeforecheck={{
+    traefik_acme_dns_delay_before_check }}
+
+# DNS challenge custom resolvers (optional)
+traefik_cli_dns_challenge_resolvers: >-
+  {{
+    ['--certificatesresolvers.' + traefik_certresolver_name +
+    '.acme.dnschallenge.resolvers=' + (traefik_acme_dns_resolvers | join(','))]
+    if traefik_acme_dns_resolvers | length > 0 else []
+  }}
+
+# Combined DNS challenge configuration
+traefik_cli_dns_challenge: "{{
+  traefik_cli_dns_challenge_base + traefik_cli_dns_challenge_resolvers
+  }}"
 
 # Email configuration for ACME (optional but recommended)
 traefik_cli_acme_email: >-
   {{
-    ['--certificatesresolvers.live.acme.email=' + traefik_acme_email]
+    ['--certificatesresolvers.' + traefik_certresolver_name + '.acme.email=' + traefik_acme_email]
     if traefik_acme_email else []
   }}
 
@@ -107,6 +133,7 @@ traefik_labels:
   traefik.http.routers.traefik_api.rule: "{{ traefik_api_rule }}"
   traefik.http.routers.traefik_api.entrypoints: "web_secure"
   traefik.http.routers.traefik_api.service: "api@internal"
+  traefik.http.routers.traefik_api.tls.certresolver: "{{ traefik_certresolver_name }}"
 
 traefik_mounts:
   - source: /var/run/docker.sock


### PR DESCRIPTION
## Summary

This PR adds support for custom certificate resolver names and custom DNS resolvers, addressing the limitations described in #4. Users can now use semantic resolver names matching their DNS provider and specify custom DNS servers for validation.

## Changes

### Core Functionality
- Add `traefik_certresolver_name` variable (default: `"live"`)
- Add `traefik_acme_dns_resolvers` variable (default: `[]`)
- Replace all 8 hardcoded `"live"` references with `{{ traefik_certresolver_name }}`
- Add conditional DNS resolvers support to DNS challenge configuration
- Update `traefik_labels` to use variable resolver name

### Configuration Variables
```yaml
# Certificate resolver name (default: "live")
traefik_certresolver_name: "live"

# Custom DNS resolvers for validation (optional)
traefik_acme_dns_resolvers:
  - "1.1.1.1:53"
  - "8.8.8.8:53"
```

### Documentation
- Updated ACME variables table with new configuration options
- Added comprehensive usage example showing custom resolver name and DNS servers
- Clear description of benefits and use cases

## Problem Solved

Previously, users wanting to:
1. Use semantic resolver names (e.g., `"hetzner"`, `"cloudflare"` instead of `"live"`)
2. Specify custom DNS resolvers for validation

Had to override entire CLI variable arrays (`traefik_cli_base`, `traefik_cli_dns_challenge`), losing:
- Role updates and improvements
- Simplified configuration
- Maintainability

## Solution Benefits

1. **Semantic Naming**: Match resolver name to DNS provider for clarity
2. **Custom DNS Resolvers**: Specify custom DNS servers for improved reliability
3. **Role Maintainability**: Users don't override entire CLI arrays
4. **Backward Compatible**: Default `"live"` maintains current behavior
5. **Simplified Customization**: Change single variables instead of complex overrides

## Example Usage

```yaml
---
- name: Deploy Traefik with Custom Resolver Name
  hosts: traefik_servers
  become: true

  vars:
    # Semantic naming matching DNS provider
    traefik_certresolver_name: "hetzner"
    traefik_acme_challenge_type: "dns"
    traefik_acme_dns_provider: "hetzner"
    traefik_acme_email: "admin@example.com"

    # Custom DNS resolvers for validation
    traefik_acme_dns_resolvers:
      - "1.1.1.1:53"
      - "8.8.8.8:53"

    traefik_acme_dns_env:
      HETZNER_API_KEY: "{{ vault_hetzner_api_key }}"

  roles:
    - tripleawwy.traefik_docker
```

## Technical Details

### Replaced References
All 8 hardcoded `"live"` references replaced:
1. `--entrypoints.web_secure.http.tls.certresolver`
2. `--certificatesresolvers.live=true`
3. HTTP challenge configuration (2 references)
4. DNS challenge configuration (3 references)
5. Email configuration (1 reference)
6. Dashboard labels (1 reference)

### DNS Resolvers Implementation
```yaml
traefik_cli_dns_challenge_resolvers: >-
  {{
    ['--certificatesresolvers.' + traefik_certresolver_name +
    '.acme.dnschallenge.resolvers=' + (traefik_acme_dns_resolvers | join(','))]
    if traefik_acme_dns_resolvers | length > 0 else []
  }}
```

## Testing

All quality checks pass:
- **yamllint**: 0 errors, 0 warnings
- **ansible-lint**: Production profile compliance
- **Backward compatibility**: Defaults maintain current behavior

## Breaking Changes

None. This PR adds new functionality while maintaining full backward compatibility. Existing deployments continue working without any changes.

## Checklist

- [x] yamllint passed
- [x] ansible-lint passed (production profile)
- [x] Documentation updated with comprehensive examples
- [x] New variables added to ACME table
- [x] Backward compatibility maintained
- [x] No breaking changes

Closes #4